### PR TITLE
Add support for url.URL

### DIFF
--- a/scalar.go
+++ b/scalar.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"net/mail"
+	"net/url"
 	"reflect"
 	"strconv"
 	"time"
@@ -19,6 +20,7 @@ var (
 	durationType        = reflect.TypeOf(time.Duration(0))
 	mailAddressType     = reflect.TypeOf(mail.Address{})
 	macType             = reflect.TypeOf(net.HardwareAddr{})
+	urlType             = reflect.TypeOf(url.URL{})
 )
 
 var (
@@ -86,6 +88,13 @@ func ParseValue(v reflect.Value, s string) error {
 		}
 		v.Set(reflect.ValueOf(ip))
 		return nil
+	case url.URL:
+		url, err := url.Parse(s)
+		if err != nil {
+			return err
+		}
+		v.Set(reflect.ValueOf(*url))
+		return nil
 	}
 
 	// Switch on kind so that we can handle derived types
@@ -136,7 +145,7 @@ func CanParse(t reflect.Type) bool {
 
 	// Check for other special types
 	switch t {
-	case durationType, mailAddressType, macType:
+	case durationType, mailAddressType, macType, urlType:
 		return true
 	}
 

--- a/scalar_test.go
+++ b/scalar_test.go
@@ -2,6 +2,7 @@ package scalar
 
 import (
 	"net"
+	"net/url"
 	"reflect"
 	"testing"
 	"time"
@@ -76,6 +77,9 @@ func TestParseValue(t *testing.T) {
 
 	// MAC addresses
 	assertParse(t, net.HardwareAddr("\x01\x23\x45\x67\x89\xab"), "01:23:45:67:89:ab")
+
+	// URL
+	assertParse(t, url.URL{Scheme: "https", Host: "example.com", Path: "/a/b/c"}, "https://example.com/a/b/c")
 
 	// custom text unmarshaler
 	assertParse(t, textUnmarshaler{3}, "abc")


### PR DESCRIPTION
Add support for `url.URL` via `url.Parse`